### PR TITLE
Disable/Enable Selector Element on Checkbox Toggle 

### DIFF
--- a/client/src/components/ChallengeCard/components/ChallengeObjectives/ChallengeObjectives.jsx
+++ b/client/src/components/ChallengeCard/components/ChallengeObjectives/ChallengeObjectives.jsx
@@ -33,6 +33,7 @@ const ChallengeObjectives = (props) => {
                                 objectiveIndex={index}
                                 progress={obj.progress}
                                 goal={obj.goal}
+                                completed={obj.completed}
                             />
                             {/* Tally Goal - Render a Percentage if Goal is a Percentage*/}
                             {!obj.isPercent &&

--- a/client/src/components/ChallengeCard/components/ObjectiveOptions/ObjectiveOptions.jsx
+++ b/client/src/components/ChallengeCard/components/ObjectiveOptions/ObjectiveOptions.jsx
@@ -5,15 +5,14 @@ const ObjectiveOptions = (props) => {
 
     const [{ week, challengeIndex, name }, dispatch] = useChallengeContext()
 
+    console.log(props.completed);
+
 
     // CAN WE GET THIS FROM CHALLENGE STATE INSTEAD OF PROPS
     const [objProgress, setObjProgress] = useState(() => {
         return props.progress
     });
 
-// NEED TO REFACTOR SO IT DOES NOT UPDATE EVERY SINGLE INSTANCE OF A CURRENT INDEX
-
-    // This came from parsedSeasonalChallenges and needs to be refactored to removed not need arguments
     const handleSelect = (e, week, challengeIndex) => {
         const userSelectedValue = e.target.value;
         // * Set Component State to Update Page
@@ -33,16 +32,13 @@ const ObjectiveOptions = (props) => {
         dispatch({type:'setNewObjective', payload: { newObjective }});
     }
 
- 
-
-    // Can we use a useEffect to listen to completed value??
-
     return (
         <select
             id={`${props.task.replaceAll(' ', '-')}`}
             value={objProgress}
             data-challenge={name.replaceAll(' ', '-')}
             data-objective-index={props.objectiveIndex}
+            disabled={props.completed}
             onChange={e => handleSelect(e, week, challengeIndex)}
         >
             <option key='default' disabled>Your Progress</option>

--- a/client/src/components/ChallengeCard/components/ObjectiveToggle/ObjectiveToggle.jsx
+++ b/client/src/components/ChallengeCard/components/ObjectiveToggle/ObjectiveToggle.jsx
@@ -6,9 +6,9 @@ const ObjectiveToggle = (props) => {
     const [{ week, challengeIndex }, dispatch] = useChallengeContext();
 
 
+    // NOTE: PROGRESS STILL DOES NOT UPDATE ACROSS PAGES
     const handleClick = (id, week, challengeIndex) => {
         const currentObjective = document.getElementById(id);
-
         // * Update Local Storage
         const getLocal = localStorage.getItem(week);
         // ** Parse Local With Mutable Variable
@@ -18,9 +18,7 @@ const ObjectiveToggle = (props) => {
         currentTask.completed = currentObjective.checked;
         // ** Store the Mutated Array in Local Storage
         localStorage.setItem(week, JSON.stringify(newLocal));
-
         // ** Dispatch Values to State for Data to Persist Between Pages
-        // NOTE: PROGRESS STILL DOES NOT UPDATE ACROSS PAGES
         const newObjective = newLocal[challengeIndex].objectives;
         dispatch({type:'setNewObjective', payload: { newObjective }});
     }


### PR DESCRIPTION
In order to preserve the user's previous progress prior to toggle the objective completed, the selector is now disabled when toggling complete on the objective. 
This lets them updated their values if they clicked the wrong one